### PR TITLE
Use @adobe/jwt-auth 0.3.0 or greater

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@adobe/jwt-auth": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/jwt-auth/-/jwt-auth-0.1.0.tgz",
-      "integrity": "sha512-/MCI16+HhGHcrPcs7JpomatgC/YTnI4qQYYX/GH3SV+l1a/j1BpHyuwb/K+s1knE28TYdKAX9pDcQmheZCxG1w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/jwt-auth/-/jwt-auth-0.3.0.tgz",
+      "integrity": "sha512-2MQ7Ld507WEaooqI0rkL00gVtBLdS4aijCAGKGarK9RmqzVCQ/5ogODdA8cFWpqwIMgKoLeXo3XtTUjuD5Q31Q==",
       "requires": {
         "form-data": "^2.3.3",
         "jsonwebtoken": "^8.4.0",
@@ -2657,9 +2657,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-      "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "nodemon": {
       "version": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint 'bin/**'"
   },
   "dependencies": {
-    "@adobe/jwt-auth": "^0.1.0",
+    "@adobe/jwt-auth": "^0.3.0",
     "chalk": "^2.4.2",
     "inquirer": "^6.3.1",
     "prettyjson": "^1.2.1",


### PR DESCRIPTION
## Description

I recently released @adobe/jwt-auth 0.3.0 which expires the temporary JWT it creates after 5 minutes. This is a security improvement I hope everyone moves to.

## Related Issue

https://github.com/adobe/jwt-auth/issues/23

## Motivation and Context

The JWT token was valid for 24 hours but since we create the bearer token shortly after creating the JWT and the JWT is never re-used it should expire quickly.

## How Has This Been Tested?

Generated an auth token, grabbed the JWT and tried to use it after 5 minutes elapsed time. It was rejected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
