### PR TITLE
PDCL-5918: Hide the user's access token during --verbose printing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
   },
   "plugins": ["header"],
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2018
   },
 
   "extends": ["plugin:prettier/recommended"],

--- a/bin/index.js
+++ b/bin/index.js
@@ -67,8 +67,20 @@ const getTechnicalAccountData = require('./getTechnicalAccountData');
 
 (async () => {
   try {
+    console.log('running releaser local')
     if (argv.verbose) {
-      require('request-debug')(require('request-promise-native'));
+      require('request-debug')(require('request-promise-native'), function (
+        type,
+        data,
+        r
+      ) {
+        const filteredData = { ...data };
+        if (filteredData.headers && filteredData.headers.Authorization) {
+          filteredData.headers.Authorization = 'Bearer [USER_ACCESS_TOKEN]';
+        }
+        console.error({ [type]: filteredData });
+        return r;
+      });
     }
 
     const environment = getEnvironment(argv);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hides the user's access token during --verbose output

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-5918

## How Has This Been Tested?

1. manual verification using releaser tool
2. `npm test`

## Screenshots (if appropriate):

### shows the access token being hidden:

![Screen Shot 2021-04-26 at 2 10 42 PM](https://user-images.githubusercontent.com/1789219/116144127-31c2f700-a699-11eb-9a8c-4c4e62394d7b.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
