### PR TITLE
Deprecate QE endpoint, nuke Integration endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The environment to which the extension package should be released. Valid options
 Private key path can also be provided by setting an environment variable. The environment variable should be named one of the following, depending on which Tags environment will be receiving the extension package:
 
 * `REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT`
-* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE`
-* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_INTEGRATION`
+* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE`
+* `REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE` (Deprecated. Please favor `REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE`)
 
 Client secret can also be provided by setting an environment variable. The environment variable should be named one of the following, depending on which Tags environment will be receiving the extension package:
 
 * `REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT`
-* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE`
-* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_INTEGRATION`
+* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE`
+* `REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE` (Deprecated. Please favor `REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE`)
 
 ## Contributing
 

--- a/bin/changeAvailability.js
+++ b/bin/changeAvailability.js
@@ -23,22 +23,23 @@ module.exports = async (
   extensionPackageFromServer,
   extensionPackageManifest,
   { apiKey },
-  verbose
+  verbose,
+  confirmPackageRelease = false
 ) => {
-  let confirmPackageRelease = false;
-
   if (extensionPackageFromServer) {
-    ({ confirmPackageRelease } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'confirmPackageRelease',
-        message: `An extension package with the name \
+    if (!confirmPackageRelease) {
+      ({ confirmPackageRelease } = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'confirmPackageRelease',
+          message: `An extension package with the name \
 ${extensionPackageFromServer.attributes.name} at version \
 ${extensionPackageFromServer.attributes.version} with development \
 availability was found on the server. Would you like to release \
 this extension package to private availability?`
-      }
-    ]));
+        }
+      ]));
+    }
   } else {
     console.log(
       'No extension package was found ' +

--- a/bin/envConfig.json
+++ b/bin/envConfig.json
@@ -9,16 +9,16 @@
   "qe": {
     "ims": "https://ims-na1-stg1.adobelogin.com",
     "scope": "https://ims-na1-stg1.adobelogin.com/s/",
-    "extensionPackages": "https://reactor-qe.adobe.io/extension_packages",
+    "extensionPackages": "https://reactor-stage.adobe.io/extension_packages",
     "privateKeyEnvVar": "REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE",
     "clientSecretEnvVar": "REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE"
   },
-  "integration": {
-    "ims": "https://ims-na1.adobelogin.com",
-    "scope": "https://ims-na1.adobelogin.com/s/",
-    "extensionPackages": "https://reactor-integration.adobe.io/extension_packages",
-    "privateKeyEnvVar": "REACTOR_IO_INTEGRATION_PRIVATE_KEY_INTEGRATION",
-    "clientSecretEnvVar": "REACTOR_IO_INTEGRATION_CLIENT_SECRET_INTEGRATION"
+  "stage": {
+    "ims": "https://ims-na1-stg1.adobelogin.com",
+    "scope": "https://ims-na1-stg1.adobelogin.com/s/",
+    "extensionPackages": "https://reactor-stage.adobe.io/extension_packages",
+    "privateKeyEnvVar": "REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE",
+    "clientSecretEnvVar": "REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE"
   },
   "production": {
     "ims": "https://ims-na1.adobelogin.com",

--- a/bin/index.js
+++ b/bin/index.js
@@ -51,6 +51,11 @@ const argv = require('yargs')
     verbose: {
       type: 'boolean',
       describe: 'Logs additional information useful for debugging.'
+    },
+    'yes-to-release': {
+      type: 'boolean',
+      describe:
+        'Answer "yes" if a development extension is found that is ready to be released.'
     }
   })
   .epilogue(
@@ -117,7 +122,8 @@ const getTechnicalAccountData = require('./getTechnicalAccountData');
       extensionPackageFromServer,
       extensionPackageManifest,
       technicalAccountData,
-      argv.verbose
+      argv.verbose,
+      argv['yes-to-release']
     );
   } catch (error) {
     if (argv.verbose || !error.code) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -19,7 +19,7 @@ const argv = require('yargs')
     'private-key': {
       type: 'string',
       describe:
-        'For authentication using an Adobe I/O integration. The local path (relative or absolute) to the RSA private key. Instructions on how to generate this key can be found in the Getting Started guide (https://developer.adobelaunch.com/guides/extensions/getting-started/) and should have been used when creating your integration through the Adobe I/O console. Optionally, rather than passing the private key path as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT, REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE, REACTOR_IO_INTEGRATION_PRIVATE_KEY_INTEGRATION, REACTOR_IO_INTEGRATION_PRIVATE_KEY'
+        'For authentication using an Adobe I/O integration. The local path (relative or absolute) to the RSA private key. Instructions on how to generate this key can be found in the Getting Started guide (https://developer.adobelaunch.com/guides/extensions/getting-started/) and should have been used when creating your integration through the Adobe I/O console. Optionally, rather than passing the private key path as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_PRIVATE_KEY_DEVELOPMENT, REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE, REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE, REACTOR_IO_INTEGRATION_PRIVATE_KEY. REACTOR_IO_INTEGRATION_PRIVATE_KEY_QE is deprecated in favor of REACTOR_IO_INTEGRATION_PRIVATE_KEY_STAGE and will be removed in the future.'
     },
     'org-id': {
       type: 'string',
@@ -39,7 +39,7 @@ const argv = require('yargs')
     'client-secret': {
       type: 'string',
       describe:
-        'For authentication using an Adobe I/O integration. Your client secret. You can find this on the overview screen for the integration you have created within the Adobe I/O console (https://console.adobe.io). Optionally, rather than passing the client secret as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package: REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT, REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE, REACTOR_IO_INTEGRATION_CLIENT_SECRET_INTEGRATION, REACTOR_IO_INTEGRATION_CLIENT_SECRET'
+        'For authentication using an Adobe I/O integration. Your client secret. You can find this on the overview screen for the integration you have created within the Adobe I/O console (https://console.adobe.io). Optionally, rather than passing the client secret as a command line argument, it can instead be provided by setting one of the following environment variables, depending on the environment that will be receiving the extension package:  REACTOR_IO_INTEGRATION_CLIENT_SECRET_DEVELOPMENT, REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE, REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE, REACTOR_IO_INTEGRATION_CLIENT_SECRET. REACTOR_IO_INTEGRATION_CLIENT_SECRET_QE is deprecated in favor of REACTOR_IO_INTEGRATION_CLIENT_SECRET_STAGE and will be removed in the future.'
     },
     environment: {
       type: 'string',
@@ -84,6 +84,15 @@ const getTechnicalAccountData = require('./getTechnicalAccountData');
     }
 
     const environment = getEnvironment(argv);
+    if (environment === 'qe') {
+      console.log(
+        chalk.bold.red(
+          "'--environment=qe' is currently redirecting to '--environment=stage' on your behalf, " +
+            'and will be removed in the future.'
+        )
+      );
+      console.log(chalk.bold.red("Prefer usage of '--environment=stage'."));
+    }
     const envSpecificConfig = envConfig[environment];
     const technicalAccountData = await getTechnicalAccountData(
       envSpecificConfig,

--- a/bin/index.js
+++ b/bin/index.js
@@ -52,10 +52,10 @@ const argv = require('yargs')
       type: 'boolean',
       describe: 'Logs additional information useful for debugging.'
     },
-    'yes-to-release': {
+    'confirm-package-release': {
       type: 'boolean',
       describe:
-        'Answer "yes" if a development extension is found that is ready to be released.'
+        'Skips the confirmation that the extension is the one you wish to release.'
     }
   })
   .epilogue(
@@ -123,7 +123,7 @@ const getTechnicalAccountData = require('./getTechnicalAccountData');
       extensionPackageManifest,
       technicalAccountData,
       argv.verbose,
-      argv['yes-to-release']
+      argv['confirm-package-release']
     );
   } catch (error) {
     if (argv.verbose || !error.code) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-releaser",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1137,9 +1137,9 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-releaser",
-  "version": "3.1.0-beta.2",
+  "version": "3.1.0",
   "description": "Command line tool for releasing Tags extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-releaser",
-  "version": "3.0.4",
+  "version": "3.1.0-beta.0",
   "description": "Command line tool for releasing Tags extensions.",
   "author": {
     "name": "Adobe Systems",
@@ -46,6 +46,6 @@
     "proxyquire": "^2.1.0"
   },
   "engines": {
-    "node": ">=14.19.3"
+    "node": ">=14.21.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-releaser",
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "description": "Command line tool for releasing Tags extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-releaser",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.2",
   "description": "Command line tool for releasing Tags extensions.",
   "author": {
     "name": "Adobe Systems",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Deprecates the usage of the {{environment=qe}} flag in favor of using {{environment=stage}}.
- Nukes the {{environment=integration}} option
- Allows passing {{confirm-package-release}} to skip the yes/no release question prompt. #13 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-10124

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Reactor Environment Restructure Jira Epic

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added a new test where the inquirer isn't mocked but we pass in the override flag

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.